### PR TITLE
fix: quick poll new torrents for size with on_add events

### DIFF
--- a/README.md
+++ b/README.md
@@ -109,6 +109,9 @@ downloading_states = ["downloading", "metaDL", "queuedDL", "stalledDL", "checkin
 
 [polling]
 interval_seconds = 30
+on_add_quick_poll_interval_seconds = 1.0
+on_add_quick_poll_max_attempts = 10
+on_add_quick_poll_max_concurrency = 32
 
 [resume]
 policy = "priority_fifo"
@@ -213,6 +216,9 @@ Config path override:
 - `disk.resume_floor_pct = 10`
 - `disk.safety_buffer_gb = 10`
 - `polling.interval_seconds = 30`
+- `polling.on_add_quick_poll_interval_seconds = 1.0`
+- `polling.on_add_quick_poll_max_attempts = 10`
+- `polling.on_add_quick_poll_max_concurrency = 32`
 - `resume.policy = "priority_fifo"`
 - `resume.strict_fifo = true`
 - `tagging.paused_tag = "diskguard_paused"`
@@ -228,6 +234,9 @@ Config path override:
 - `DISKGUARD_DISK_WATCH_PATH=/downloads`
 - `DISKGUARD_DISK_SOFT_PAUSE_BELOW_PCT=10`
 - `DISKGUARD_SERVER_PORT=7070`
+- `DISKGUARD_ON_ADD_QUICK_POLL_INTERVAL_SECONDS=1.0`
+- `DISKGUARD_ON_ADD_QUICK_POLL_MAX_ATTEMPTS=10`
+- `DISKGUARD_ON_ADD_QUICK_POLL_MAX_CONCURRENCY=32`
 - `DISKGUARD_RESUME_POLICY=priority_fifo`
 - `DISKGUARD_RESUME_STRICT_FIFO=true`
 - `DISKGUARD_LOGGING_LEVEL=DEBUG`

--- a/examples/config.example.toml
+++ b/examples/config.example.toml
@@ -33,6 +33,12 @@ downloading_states = ["downloading", "metaDL", "queuedDL", "stalledDL", "checkin
 [polling]
 # Seconds between enforcement ticks. Default: 30. Type: int.
 interval_seconds = 30
+# Seconds between on-add quick poll attempts in SOFT/HARD. Default: 1.0. Type: float.
+on_add_quick_poll_interval_seconds = 1.0
+# Maximum on-add quick poll attempts per torrent hash in SOFT/HARD. Default: 10. Type: int.
+on_add_quick_poll_max_attempts = 10
+# Maximum concurrent on-add quick poll tasks. Default: 32. Type: int.
+on_add_quick_poll_max_concurrency = 32
 
 [resume]
 # Resume candidate ordering policy. Default: "priority_fifo". Type: string enum (smallest_first|priority_fifo|largest_first).

--- a/src/diskguard/api.py
+++ b/src/diskguard/api.py
@@ -11,7 +11,7 @@ from aiohttp import web
 from diskguard.config import AppConfig
 from diskguard.errors import DiskProbeError, QbittorrentError
 from diskguard.models import Mode
-from diskguard.state import classify_mode
+from diskguard.state import classify_mode, is_downloading_ish_state, is_forced_download_state
 
 
 class WarningRateLimiter:
@@ -75,6 +75,10 @@ class OnAddHandler:
         self._logger = logger or logging.getLogger(__name__)
         self._warning_rate_limiter = warning_rate_limiter or WarningRateLimiter()
         self._background_tasks: set[asyncio.Task[None]] = set()
+        self._on_add_tasks_by_hash: dict[str, asyncio.Task[None]] = {}
+        self._quick_poll_semaphore = asyncio.Semaphore(
+            self._config.polling.on_add_quick_poll_max_concurrency
+        )
 
     async def handle(self, request: web.Request) -> web.Response:
         """Processes an on-add callback and schedules background work if needed.
@@ -133,12 +137,26 @@ class OnAddHandler:
         if mode is Mode.NORMAL:
             return web.json_response({"status": "ok", "action": "none", "mode": mode.value}, status=200)
 
-        # Keep the endpoint non-blocking: pause/tag work executes in background.
-        task = asyncio.create_task(self._pause_and_mark(torrent_hash, mode))
+        # Keep the endpoint non-blocking: quick-poll + pause/tag executes in background.
+        existing_task = self._on_add_tasks_by_hash.get(torrent_hash)
+        if existing_task is not None and not existing_task.done():
+            return web.json_response(
+                {"status": "accepted", "action": "quick_poll_already_scheduled", "mode": mode.value},
+                status=202,
+            )
+
+        task = asyncio.create_task(self._quick_poll_then_pause_and_mark(torrent_hash, mode))
         self._background_tasks.add(task)
-        task.add_done_callback(self._background_tasks.discard)
+        self._on_add_tasks_by_hash[torrent_hash] = task
+
+        def _cleanup_task(done_task: asyncio.Task[None]) -> None:
+            self._background_tasks.discard(done_task)
+            if self._on_add_tasks_by_hash.get(torrent_hash) is done_task:
+                self._on_add_tasks_by_hash.pop(torrent_hash, None)
+
+        task.add_done_callback(_cleanup_task)
         return web.json_response(
-            {"status": "accepted", "action": "pause_and_mark", "mode": mode.value},
+            {"status": "accepted", "action": "quick_poll_pause_and_mark", "mode": mode.value},
             status=202,
         )
 
@@ -194,6 +212,49 @@ class OnAddHandler:
                 torrent_hash,
                 exc,
             )
+
+    async def _quick_poll_then_pause_and_mark(self, torrent_hash: str, mode: Mode) -> None:
+        """Quick-polls a single torrent until size is known, then pauses/tags it."""
+        max_attempts = self._config.polling.on_add_quick_poll_max_attempts
+        interval_seconds = self._config.polling.on_add_quick_poll_interval_seconds
+        downloading_states = self._config.disk.downloading_states
+
+        async with self._quick_poll_semaphore:
+            for attempt in range(1, max_attempts + 1):
+                try:
+                    snapshot = await self._qb_client.fetch_torrent_by_hash(torrent_hash)
+                except QbittorrentError as exc:
+                    self._warn_rate_limited(
+                        "on_add_qb_failure",
+                        "on-add quick poll failed for torrent %s: %s",
+                        torrent_hash,
+                        exc,
+                    )
+                    return
+
+                if snapshot is not None:
+                    amount_left = snapshot.amount_left
+                    if amount_left is not None and amount_left > 0:
+                        if is_forced_download_state(snapshot.state):
+                            self._logger.debug(
+                                "on-add quick poll skipping forcedDL torrent %s in %s mode",
+                                torrent_hash,
+                                mode.value,
+                            )
+                            return
+
+                        if is_downloading_ish_state(snapshot.state, downloading_states):
+                            await self._pause_and_mark(torrent_hash, mode)
+                            return
+
+                if attempt < max_attempts:
+                    await asyncio.sleep(interval_seconds)
+
+        self._logger.debug(
+            "on-add quick poll exhausted for %s after %d attempts without pausing",
+            torrent_hash,
+            max_attempts,
+        )
 
     def _warn_rate_limited(self, key: str, message: str, *args: object) -> None:
         """Logs a warning only if rate limiter allows it.

--- a/src/diskguard/config.py
+++ b/src/diskguard/config.py
@@ -40,6 +40,9 @@ downloading_states = ["downloading", "metaDL", "queuedDL", "stalledDL", "checkin
 
 [polling]
 interval_seconds = 30
+on_add_quick_poll_interval_seconds = 1.0
+on_add_quick_poll_max_attempts = 10
+on_add_quick_poll_max_concurrency = 32
 
 [resume]
 policy = "priority_fifo"
@@ -98,6 +101,9 @@ class PollingConfig:
     """Polling loop settings."""
 
     interval_seconds: int = 30
+    on_add_quick_poll_interval_seconds: float = 1.0
+    on_add_quick_poll_max_attempts: int = 10
+    on_add_quick_poll_max_concurrency: int = 32
 
 
 @dataclass(frozen=True)
@@ -248,6 +254,21 @@ ENV_OVERRIDES: dict[str, tuple[str, str, EnvParser]] = {
     "DISKGUARD_DISK_SAFETY_BUFFER_GB": ("disk", "safety_buffer_gb", _parse_float),
     "DISKGUARD_DISK_DOWNLOADING_STATES": ("disk", "downloading_states", _parse_csv),
     "DISKGUARD_POLLING_INTERVAL_SECONDS": ("polling", "interval_seconds", _parse_int),
+    "DISKGUARD_ON_ADD_QUICK_POLL_INTERVAL_SECONDS": (
+        "polling",
+        "on_add_quick_poll_interval_seconds",
+        _parse_float,
+    ),
+    "DISKGUARD_ON_ADD_QUICK_POLL_MAX_ATTEMPTS": (
+        "polling",
+        "on_add_quick_poll_max_attempts",
+        _parse_int,
+    ),
+    "DISKGUARD_ON_ADD_QUICK_POLL_MAX_CONCURRENCY": (
+        "polling",
+        "on_add_quick_poll_max_concurrency",
+        _parse_int,
+    ),
     "DISKGUARD_RESUME_POLICY": ("resume", "policy", str),
     "DISKGUARD_RESUME_STRICT_FIFO": ("resume", "strict_fifo", _parse_bool),
     "DISKGUARD_TAGGING_PAUSED_TAG": ("tagging", "paused_tag", str),
@@ -480,7 +501,19 @@ def _build_config(raw: dict[str, Any]) -> AppConfig:
     )
 
     polling_config = PollingConfig(
-        interval_seconds=_as_int(polling_section.get("interval_seconds", 30), "polling.interval_seconds")
+        interval_seconds=_as_int(polling_section.get("interval_seconds", 30), "polling.interval_seconds"),
+        on_add_quick_poll_interval_seconds=_as_float(
+            polling_section.get("on_add_quick_poll_interval_seconds", 1.0),
+            "polling.on_add_quick_poll_interval_seconds",
+        ),
+        on_add_quick_poll_max_attempts=_as_int(
+            polling_section.get("on_add_quick_poll_max_attempts", 10),
+            "polling.on_add_quick_poll_max_attempts",
+        ),
+        on_add_quick_poll_max_concurrency=_as_int(
+            polling_section.get("on_add_quick_poll_max_concurrency", 32),
+            "polling.on_add_quick_poll_max_concurrency",
+        ),
     )
 
     tagging_config = TaggingConfig(
@@ -662,6 +695,12 @@ def _validate(config: AppConfig) -> None:
         raise ConfigError("disk.safety_buffer_gb must be non-negative")
     if config.polling.interval_seconds <= 0:
         raise ConfigError("polling.interval_seconds must be greater than zero")
+    if config.polling.on_add_quick_poll_interval_seconds <= 0:
+        raise ConfigError("polling.on_add_quick_poll_interval_seconds must be greater than zero")
+    if config.polling.on_add_quick_poll_max_attempts <= 0:
+        raise ConfigError("polling.on_add_quick_poll_max_attempts must be greater than zero")
+    if config.polling.on_add_quick_poll_max_concurrency <= 0:
+        raise ConfigError("polling.on_add_quick_poll_max_concurrency must be greater than zero")
     if config.qbittorrent.connect_timeout_seconds <= 0:
         raise ConfigError("qbittorrent.connect_timeout_seconds must be greater than zero")
     if config.qbittorrent.read_timeout_seconds <= 0:

--- a/src/diskguard/engine.py
+++ b/src/diskguard/engine.py
@@ -208,6 +208,8 @@ class ModeEngine:
                     known_soft_allowed.add(torrent.hash)
 
         for torrent in torrents:
+            if torrent.amount_left is None or torrent.amount_left <= 0:
+                continue
             if is_forced_download_state(torrent.state):
                 continue
             if not is_downloading_ish_state(torrent.state, downloading_states):
@@ -236,6 +238,8 @@ class ModeEngine:
                 await self._remove_tag(torrent.hash, soft_tag, reason="hard_cleanup")
 
         for torrent in torrents:
+            if torrent.amount_left is None or torrent.amount_left <= 0:
+                continue
             if is_forced_download_state(torrent.state):
                 continue
             if not is_downloading_ish_state(torrent.state, downloading_states):

--- a/src/diskguard/qbittorrent.py
+++ b/src/diskguard/qbittorrent.py
@@ -51,28 +51,29 @@ class QbittorrentClient:
 
         torrents: list[TorrentSnapshot] = []
         for item in payload:
-            if not isinstance(item, dict):
-                continue
-            torrent_hash = str(item.get("hash", "")).strip()
-            if not torrent_hash:
-                continue
-
-            amount_left_raw = item.get("amount_left")
-            amount_left = _coerce_optional_int(amount_left_raw)
-
-            torrents.append(
-                TorrentSnapshot(
-                    hash=torrent_hash,
-                    state=str(item.get("state", "")),
-                    amount_left=amount_left,
-                    priority=_coerce_int(item.get("priority"), default=0),
-                    added_on=_coerce_int(item.get("added_on"), default=0),
-                    tags=parse_tags(_coerce_optional_string(item.get("tags"))),
-                    name=_coerce_optional_string(item.get("name")),
-                    category=_coerce_optional_string(item.get("category")),
-                )
-            )
+            parsed = _parse_torrent_item(item)
+            if parsed is not None:
+                torrents.append(parsed)
         return torrents
+
+    async def fetch_torrent_by_hash(self, torrent_hash: str) -> TorrentSnapshot | None:
+        """Fetches one torrent by hash from the qBittorrent API."""
+        payload = await self._request(
+            "GET",
+            "/api/v2/torrents/info",
+            params={"hashes": torrent_hash},
+            expect_json=True,
+        )
+        if not isinstance(payload, list):
+            raise QbittorrentRequestError("Unexpected torrents/info payload shape")
+
+        for item in payload:
+            parsed = _parse_torrent_item(item)
+            if parsed is None:
+                continue
+            if parsed.hash == torrent_hash:
+                return parsed
+        return None
 
     async def fetch_application_version(self) -> str:
         """Fetches qBittorrent application version via authenticated API call."""
@@ -294,3 +295,25 @@ def _coerce_optional_string(value: Any) -> str | None:
     if not converted:
         return None
     return converted
+
+
+def _parse_torrent_item(item: Any) -> TorrentSnapshot | None:
+    if not isinstance(item, dict):
+        return None
+    torrent_hash = str(item.get("hash", "")).strip()
+    if not torrent_hash:
+        return None
+
+    amount_left_raw = item.get("amount_left")
+    amount_left = _coerce_optional_int(amount_left_raw)
+
+    return TorrentSnapshot(
+        hash=torrent_hash,
+        state=str(item.get("state", "")),
+        amount_left=amount_left,
+        priority=_coerce_int(item.get("priority"), default=0),
+        added_on=_coerce_int(item.get("added_on"), default=0),
+        tags=parse_tags(_coerce_optional_string(item.get("tags"))),
+        name=_coerce_optional_string(item.get("name")),
+        category=_coerce_optional_string(item.get("category")),
+    )

--- a/src/diskguard/version.py
+++ b/src/diskguard/version.py
@@ -1,3 +1,3 @@
 """DiskGuard application version."""
 
-APP_VERSION = "0.5.5"
+APP_VERSION = "0.5.6"

--- a/tests/helpers.py
+++ b/tests/helpers.py
@@ -37,6 +37,9 @@ def make_config(
         "allocating",
     ),
     interval_seconds: int = 30,
+    on_add_quick_poll_interval_seconds: float = 1.0,
+    on_add_quick_poll_max_attempts: int = 10,
+    on_add_quick_poll_max_concurrency: int = 32,
 ) -> AppConfig:
     """Creates a full AppConfig for tests."""
     return AppConfig(
@@ -53,7 +56,12 @@ def make_config(
             safety_buffer_gb=safety_buffer_gb,
             downloading_states=downloading_states,
         ),
-        polling=PollingConfig(interval_seconds=interval_seconds),
+        polling=PollingConfig(
+            interval_seconds=interval_seconds,
+            on_add_quick_poll_interval_seconds=on_add_quick_poll_interval_seconds,
+            on_add_quick_poll_max_attempts=on_add_quick_poll_max_attempts,
+            on_add_quick_poll_max_concurrency=on_add_quick_poll_max_concurrency,
+        ),
         resume=ResumeConfig(policy=policy, strict_fifo=strict_fifo),
         tagging=TaggingConfig(paused_tag=paused_tag, soft_allowed_tag=soft_allowed_tag),
         logging=LoggingConfig(level="DEBUG"),
@@ -107,21 +115,27 @@ class FakeQbClient:
         self,
         *,
         torrents_sequence: list[list[TorrentSnapshot]] | None = None,
+        torrent_lookup_sequence: dict[str, list[TorrentSnapshot | None]] | None = None,
         fetch_error: Exception | None = None,
+        fail_fetch_torrent: set[str] | None = None,
         fail_pause: set[str] | None = None,
         fail_resume: set[str] | None = None,
         fail_add_tag: set[tuple[str, str]] | None = None,
         fail_remove_tag: set[tuple[str, str]] | None = None,
     ) -> None:
         self._torrents_sequence = torrents_sequence or [[]]
+        self._torrent_lookup_sequence = torrent_lookup_sequence or {}
+        self._torrent_lookup_calls_by_hash: dict[str, int] = {}
         self._fetch_error = fetch_error
         self._fetch_calls = 0
 
+        self.fail_fetch_torrent = fail_fetch_torrent or set()
         self.fail_pause = fail_pause or set()
         self.fail_resume = fail_resume or set()
         self.fail_add_tag = fail_add_tag or set()
         self.fail_remove_tag = fail_remove_tag or set()
 
+        self.fetch_torrent_calls: list[str] = []
         self.pause_calls: list[str] = []
         self.resume_calls: list[str] = []
         self.add_tag_calls: list[tuple[str, str]] = []
@@ -137,6 +151,26 @@ class FakeQbClient:
             raise self._fetch_error
         index = min(self._fetch_calls - 1, len(self._torrents_sequence) - 1)
         return self._torrents_sequence[index]
+
+    async def fetch_torrent_by_hash(self, torrent_hash: str) -> TorrentSnapshot | None:
+        self.fetch_torrent_calls.append(torrent_hash)
+        if torrent_hash in self.fail_fetch_torrent:
+            raise QbittorrentUnavailableError(f"fetch torrent failed for {torrent_hash}")
+
+        lookup_sequence = self._torrent_lookup_sequence.get(torrent_hash)
+        if lookup_sequence is not None:
+            calls = self._torrent_lookup_calls_by_hash.get(torrent_hash, 0)
+            index = min(calls, len(lookup_sequence) - 1)
+            self._torrent_lookup_calls_by_hash[torrent_hash] = calls + 1
+            return lookup_sequence[index]
+
+        if not self._torrents_sequence:
+            return None
+        index = min(self._fetch_calls, len(self._torrents_sequence) - 1)
+        for torrent in self._torrents_sequence[index]:
+            if torrent.hash == torrent_hash:
+                return torrent
+        return None
 
     async def pause_torrent(self, torrent_hash: str) -> None:
         self.pause_calls.append(torrent_hash)

--- a/tests/test_api_on_add.py
+++ b/tests/test_api_on_add.py
@@ -6,7 +6,7 @@ import logging
 from aiohttp.test_utils import TestClient, TestServer
 
 from diskguard.api import OnAddHandler, create_http_app
-from tests.helpers import FakeDiskProbe, FakeQbClient, disk_stats, make_config
+from tests.helpers import FakeDiskProbe, FakeQbClient, disk_stats, make_config, torrent
 
 
 async def test_on_add_in_normal_mode_does_nothing() -> None:
@@ -28,8 +28,12 @@ async def test_on_add_in_normal_mode_does_nothing() -> None:
 
 
 async def test_on_add_in_soft_mode_pauses_and_tags_hash() -> None:
-    config = make_config()
-    qb = FakeQbClient()
+    config = make_config(on_add_quick_poll_interval_seconds=0.01, on_add_quick_poll_max_attempts=2)
+    qb = FakeQbClient(
+        torrent_lookup_sequence={
+            "abc": [torrent("abc", state="downloading", amount_left=10)],
+        }
+    )
     probe = FakeDiskProbe(stats_sequence=[disk_stats(total_bytes=1_000, free_bytes=90)])
     handler = OnAddHandler(config, qb_client=qb, disk_probe=probe)
 
@@ -38,6 +42,8 @@ async def test_on_add_in_soft_mode_pauses_and_tags_hash() -> None:
         async with TestClient(server) as client:
             response = await client.post("/on-add", data={"hash": "abc"})
             assert response.status == 202
+            payload = await response.json()
+            assert payload["action"] == "quick_poll_pause_and_mark"
             await handler.shutdown()
 
     assert qb.pause_calls == ["abc"]
@@ -61,8 +67,13 @@ async def test_on_add_requires_hash() -> None:
 
 
 async def test_on_add_returns_accepted_when_qb_is_temporarily_unavailable() -> None:
-    config = make_config()
-    qb = FakeQbClient(fail_pause={"abc"})
+    config = make_config(on_add_quick_poll_interval_seconds=0.01, on_add_quick_poll_max_attempts=1)
+    qb = FakeQbClient(
+        torrent_lookup_sequence={
+            "abc": [torrent("abc", state="downloading", amount_left=10)],
+        },
+        fail_pause={"abc"},
+    )
     probe = FakeDiskProbe(stats_sequence=[disk_stats(total_bytes=1_000, free_bytes=90)])
     handler = OnAddHandler(config, qb_client=qb, disk_probe=probe)
 
@@ -78,13 +89,22 @@ async def test_on_add_returns_accepted_when_qb_is_temporarily_unavailable() -> N
 
 
 async def test_on_add_handles_parallel_calls_without_state_corruption() -> None:
-    config = make_config()
-    qb = FakeQbClient()
+    config = make_config(
+        on_add_quick_poll_interval_seconds=0.01,
+        on_add_quick_poll_max_attempts=2,
+        on_add_quick_poll_max_concurrency=4,
+    )
+    hashes = [f"h{i:02d}" for i in range(20)]
+    qb = FakeQbClient(
+        torrent_lookup_sequence={
+            torrent_hash: [torrent(torrent_hash, state="downloading", amount_left=10)]
+            for torrent_hash in hashes
+        }
+    )
     probe = FakeDiskProbe(stats_sequence=[disk_stats(total_bytes=1_000, free_bytes=90)])
     handler = OnAddHandler(config, qb_client=qb, disk_probe=probe)
 
     app = create_http_app(handler)
-    hashes = [f"h{i:02d}" for i in range(20)]
     async with TestServer(app) as server:
         async with TestClient(server) as client:
             responses = await asyncio.gather(
@@ -95,6 +115,34 @@ async def test_on_add_handles_parallel_calls_without_state_corruption() -> None:
 
     assert sorted(qb.pause_calls) == sorted(hashes)
     assert sorted(hash_value for hash_value, _ in qb.add_tag_calls) == sorted(hashes)
+
+
+async def test_on_add_deduplicates_quick_poll_for_same_hash() -> None:
+    config = make_config(on_add_quick_poll_interval_seconds=0.05, on_add_quick_poll_max_attempts=2)
+    qb = FakeQbClient(
+        torrent_lookup_sequence={
+            "abc": [
+                torrent("abc", state="metaDL", amount_left=0),
+                torrent("abc", state="downloading", amount_left=10),
+            ]
+        }
+    )
+    probe = FakeDiskProbe(stats_sequence=[disk_stats(total_bytes=1_000, free_bytes=90)])
+    handler = OnAddHandler(config, qb_client=qb, disk_probe=probe)
+
+    app = create_http_app(handler)
+    async with TestServer(app) as server:
+        async with TestClient(server) as client:
+            first, second = await asyncio.gather(
+                client.post("/on-add", data={"hash": "abc"}),
+                client.post("/on-add", data={"hash": "abc"}),
+            )
+            assert first.status == 202
+            assert second.status == 202
+            await handler.shutdown()
+
+    assert qb.pause_calls == ["abc"]
+    assert qb.add_tag_calls == [("abc", "diskguard_paused")]
 
 
 async def test_on_add_logs_info_with_hash_on_hook_call(
@@ -153,3 +201,55 @@ async def test_on_add_logs_optional_name_and_category_when_present(
     assert "hash=abc" in on_add_logs[0]
     assert "name=Ubuntu ISO" in on_add_logs[0]
     assert "category=linux" in on_add_logs[0]
+
+
+async def test_on_add_quick_poll_waits_until_known_size_before_pause() -> None:
+    config = make_config(on_add_quick_poll_interval_seconds=0.01, on_add_quick_poll_max_attempts=3)
+    qb = FakeQbClient(
+        torrent_lookup_sequence={
+            "abc": [
+                torrent("abc", state="metaDL", amount_left=0),
+                torrent("abc", state="metaDL", amount_left=None),
+                torrent("abc", state="downloading", amount_left=10),
+            ]
+        }
+    )
+    probe = FakeDiskProbe(stats_sequence=[disk_stats(total_bytes=1_000, free_bytes=90)])
+    handler = OnAddHandler(config, qb_client=qb, disk_probe=probe)
+
+    app = create_http_app(handler)
+    async with TestServer(app) as server:
+        async with TestClient(server) as client:
+            response = await client.post("/on-add", data={"hash": "abc"})
+            assert response.status == 202
+            await handler.shutdown()
+
+    assert qb.fetch_torrent_calls == ["abc", "abc", "abc"]
+    assert qb.pause_calls == ["abc"]
+    assert qb.add_tag_calls == [("abc", "diskguard_paused")]
+
+
+async def test_on_add_quick_poll_does_not_pause_when_size_stays_unknown() -> None:
+    config = make_config(on_add_quick_poll_interval_seconds=0.01, on_add_quick_poll_max_attempts=3)
+    qb = FakeQbClient(
+        torrent_lookup_sequence={
+            "abc": [
+                torrent("abc", state="metaDL", amount_left=0),
+                torrent("abc", state="metaDL", amount_left=None),
+                torrent("abc", state="metaDL", amount_left=0),
+            ]
+        }
+    )
+    probe = FakeDiskProbe(stats_sequence=[disk_stats(total_bytes=1_000, free_bytes=90)])
+    handler = OnAddHandler(config, qb_client=qb, disk_probe=probe)
+
+    app = create_http_app(handler)
+    async with TestServer(app) as server:
+        async with TestClient(server) as client:
+            response = await client.post("/on-add", data={"hash": "abc"})
+            assert response.status == 202
+            await handler.shutdown()
+
+    assert qb.fetch_torrent_calls == ["abc", "abc", "abc"]
+    assert qb.pause_calls == []
+    assert qb.add_tag_calls == []

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -31,6 +31,9 @@ watch_path = "/downloads"
     assert config.disk.soft_pause_below_pct == 10.0
     assert config.resume.policy.value == "priority_fifo"
     assert config.server.port == 7070
+    assert config.polling.on_add_quick_poll_interval_seconds == 1.0
+    assert config.polling.on_add_quick_poll_max_attempts == 10
+    assert config.polling.on_add_quick_poll_max_concurrency == 32
 
 
 def test_load_config_defaults_watch_path_when_missing(tmp_path: Path) -> None:
@@ -71,12 +74,18 @@ strict_fifo = true
     monkeypatch.setenv("DISKGUARD_RESUME_POLICY", "smallest_first")
     monkeypatch.setenv("DISKGUARD_RESUME_STRICT_FIFO", "false")
     monkeypatch.setenv("DISKGUARD_POLLING_INTERVAL_SECONDS", "45")
+    monkeypatch.setenv("DISKGUARD_ON_ADD_QUICK_POLL_INTERVAL_SECONDS", "0.5")
+    monkeypatch.setenv("DISKGUARD_ON_ADD_QUICK_POLL_MAX_ATTEMPTS", "20")
+    monkeypatch.setenv("DISKGUARD_ON_ADD_QUICK_POLL_MAX_CONCURRENCY", "12")
     monkeypatch.setenv("DISKGUARD_DISK_DOWNLOADING_STATES", "downloading,metaDL")
 
     config = load_config(str(config_file))
     assert config.resume.policy.value == "smallest_first"
     assert config.resume.strict_fifo is False
     assert config.polling.interval_seconds == 45
+    assert config.polling.on_add_quick_poll_interval_seconds == 0.5
+    assert config.polling.on_add_quick_poll_max_attempts == 20
+    assert config.polling.on_add_quick_poll_max_concurrency == 12
     assert config.disk.downloading_states == ("downloading", "metaDL")
 
 

--- a/tests/test_engine.py
+++ b/tests/test_engine.py
@@ -33,6 +33,30 @@ async def test_normal_to_soft_transition_adds_soft_allowed_without_pausing_exist
     assert "a" not in qb.pause_calls
 
 
+async def test_normal_to_soft_transition_tags_unknown_size_downloaders_as_soft_allowed() -> None:
+    config = make_config()
+    qb = FakeQbClient(
+        torrents_sequence=[
+            [],
+            [torrent("meta", state="metaDL", amount_left=0)],
+        ]
+    )
+    probe = FakeDiskProbe(
+        stats_sequence=[
+            disk_stats(total_bytes=1_000, free_bytes=200),  # NORMAL (20%)
+            disk_stats(total_bytes=1_000, free_bytes=90),  # SOFT (9%)
+        ]
+    )
+    planner = ResumePlanner(config, qb)
+    engine = ModeEngine(config, qb_client=qb, disk_probe=probe, resume_planner=planner)
+
+    await engine.tick()
+    await engine.tick()
+
+    assert ("meta", "soft_allowed") in qb.add_tag_calls
+    assert "meta" not in qb.pause_calls
+
+
 async def test_soft_mode_steady_enforcement_pauses_new_downloaders() -> None:
     config = make_config()
     qb = FakeQbClient(
@@ -62,6 +86,31 @@ async def test_soft_mode_steady_enforcement_pauses_new_downloaders() -> None:
     assert "new" in qb.pause_calls
     assert ("new", "diskguard_paused") in qb.add_tag_calls
     assert "old" not in qb.pause_calls
+
+
+async def test_soft_mode_ignores_unknown_size_until_size_is_known() -> None:
+    config = make_config()
+    qb = FakeQbClient(
+        torrents_sequence=[
+            [torrent("new", state="downloading", amount_left=0)],
+            [torrent("new", state="downloading", amount_left=25)],
+        ]
+    )
+    probe = FakeDiskProbe(
+        stats_sequence=[
+            disk_stats(total_bytes=1_000, free_bytes=90),  # SOFT
+            disk_stats(total_bytes=1_000, free_bytes=90),  # SOFT
+        ]
+    )
+    planner = ResumePlanner(config, qb)
+    engine = ModeEngine(config, qb_client=qb, disk_probe=probe, resume_planner=planner)
+
+    await engine.tick()
+    assert qb.pause_calls == []
+
+    await engine.tick()
+    assert qb.pause_calls == ["new"]
+    assert qb.add_tag_calls == [("new", "diskguard_paused")]
 
 
 async def test_hard_mode_pauses_all_downloading_non_forced_and_cleans_soft_tags() -> None:
@@ -94,6 +143,31 @@ async def test_hard_mode_pauses_all_downloading_non_forced_and_cleans_soft_tags(
     assert "forced" not in qb.pause_calls
     assert ("base", "diskguard_paused") in qb.add_tag_calls
     assert ("x", "diskguard_paused") in qb.add_tag_calls
+
+
+async def test_hard_mode_ignores_unknown_size_until_size_is_known() -> None:
+    config = make_config()
+    qb = FakeQbClient(
+        torrents_sequence=[
+            [torrent("x", state="downloading", amount_left=0)],
+            [torrent("x", state="downloading", amount_left=10)],
+        ]
+    )
+    probe = FakeDiskProbe(
+        stats_sequence=[
+            disk_stats(total_bytes=1_000, free_bytes=40),  # HARD
+            disk_stats(total_bytes=1_000, free_bytes=40),  # HARD
+        ]
+    )
+    planner = ResumePlanner(config, qb)
+    engine = ModeEngine(config, qb_client=qb, disk_probe=probe, resume_planner=planner)
+
+    await engine.tick()
+    assert qb.pause_calls == []
+
+    await engine.tick()
+    assert qb.pause_calls == ["x"]
+    assert qb.add_tag_calls == [("x", "diskguard_paused")]
 
 
 async def test_normal_mode_self_heals_drifted_paused_tag_and_resumes_candidates() -> None:

--- a/tests/test_qbittorrent_client.py
+++ b/tests/test_qbittorrent_client.py
@@ -73,6 +73,78 @@ async def test_fetch_torrents_retries_once_after_403_with_relogin() -> None:
     assert torrents[0].tags == frozenset({"diskguard_paused", "soft_allowed"})
 
 
+async def test_fetch_torrent_by_hash_uses_filtered_info_endpoint() -> None:
+    state = {
+        "path_qs": "",
+    }
+
+    async def login_handler(_: web.Request) -> web.Response:
+        return web.Response(text="Ok.")
+
+    async def info_handler(request: web.Request) -> web.Response:
+        state["path_qs"] = request.path_qs
+        return web.json_response(
+            [
+                {
+                    "hash": "abc123",
+                    "state": "metaDL",
+                    "amount_left": 0,
+                    "priority": 1,
+                    "added_on": 123,
+                    "tags": "diskguard_paused",
+                }
+            ]
+        )
+
+    app = web.Application()
+    app.router.add_post("/api/v2/auth/login", login_handler)
+    app.router.add_get("/api/v2/torrents/info", info_handler)
+
+    async with TestServer(app) as server:
+        config = QbittorrentConfig(
+            url=str(server.make_url("/")).rstrip("/"),
+            username="admin",
+            password="password",
+        )
+        client = QbittorrentClient(config)
+        try:
+            snapshot = await client.fetch_torrent_by_hash("abc123")
+        finally:
+            await client.close()
+
+    assert state["path_qs"] == "/api/v2/torrents/info?hashes=abc123"
+    assert snapshot is not None
+    assert snapshot.hash == "abc123"
+    assert snapshot.state == "metaDL"
+    assert snapshot.amount_left == 0
+
+
+async def test_fetch_torrent_by_hash_returns_none_when_missing() -> None:
+    async def login_handler(_: web.Request) -> web.Response:
+        return web.Response(text="Ok.")
+
+    async def info_handler(_: web.Request) -> web.Response:
+        return web.json_response([])
+
+    app = web.Application()
+    app.router.add_post("/api/v2/auth/login", login_handler)
+    app.router.add_get("/api/v2/torrents/info", info_handler)
+
+    async with TestServer(app) as server:
+        config = QbittorrentConfig(
+            url=str(server.make_url("/")).rstrip("/"),
+            username="admin",
+            password="password",
+        )
+        client = QbittorrentClient(config)
+        try:
+            snapshot = await client.fetch_torrent_by_hash("missing")
+        finally:
+            await client.close()
+
+    assert snapshot is None
+
+
 async def test_fetch_application_version_uses_authenticated_endpoint() -> None:
     state = {
         "login_calls": 0,


### PR DESCRIPTION
This should fix a bug where torrents with unknown or 0 size do not resume if they are added while in SOFT or HARD mode.